### PR TITLE
Bugfix for update_interval

### DIFF
--- a/custom_components/reaper/__init__.py
+++ b/custom_components/reaper/__init__.py
@@ -88,7 +88,7 @@ class ReaperDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize."""
         self.hostname = hostname
         self.port = port
-        self.update_interval = update_interval
+        self.update_interval = timedelta(seconds=update_interval)
         self.reaperdaw = Reaper(session, hostname, port, username, password)
 
         super().__init__(


### PR DESCRIPTION
HA apparently changed their requirements a few releases ago that changed how and when they access update_interval, leading to exceptions due to it not being a timedelta and having the requisite attribute.  Changed the init to just make the self.update_interval a casted timedelta